### PR TITLE
Add CI Build configurations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,17 @@
+build_script:
+  - cmd: >-
+      dotnet restore
+      
+      dotnet build CloudKit.sln --configuration Release
+
+environment:
+  global:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+test: off
+image:
+  - Visual Studio 2017
+  - Ubuntu
+skip_commits:
+  files:
+    - '**/*.md'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: csharp
+solution: CloudKit.sln
+mono: none
+dotnet: 2.1
+script:
+ - dotnet restore
+ - dotnet build ./CloudKit.sln --configuration Release

--- a/CloudKit.Cli/Program.cs
+++ b/CloudKit.Cli/Program.cs
@@ -149,7 +149,6 @@ namespace CloudKit.Cli
             Console.WriteLine("Successfully logged on!");
 
             // at this point, we'd be able to perform actions on Steam
-
         }
 
         static void OnLoggedOff(SteamUser.LoggedOffCallback callback)
@@ -211,7 +210,9 @@ namespace CloudKit.Cli
         static async void DownloadFiles(uint appID)
         {
             if (steamCloud == null)
+            {
                 return;
+            }
 
             var fileListInfo = await steamCloud.GetFileListForApp(appID);
 
@@ -225,7 +226,6 @@ namespace CloudKit.Cli
 
                 using (var client = new HttpClient())
                 {
-
                     foreach (var header in downloadFileInfo.RequestHeaders)
                     {
                         client.DefaultRequestHeaders.Add(header.Name, header.Value);
@@ -327,7 +327,7 @@ namespace CloudKit.Cli
 
         static async void CommitFile(uint appID, string fileName, byte[] fileData, bool commit)
         {
-            var commitFileUploadFailResp = await steamCloud.CommitFileUpload(appID, fileName, fileData, commit);
+            await steamCloud.CommitFileUpload(appID, fileName, fileData, commit);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A toolkit for accessing user/saved game data on Valve's Steam network directly without going through the Steam client.
 
+## Build status
+
+| Build server    | Build status                                                                                                                                                            |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AppVeyor        | [![Build status](https://ci.appveyor.com/api/projects/status/xpxj4i1nucsaummr/branch/master?svg=true)](https://ci.appveyor.com/project/unknownv2/cloudkit/branch/master)|
+| Travis CI       | [![Build Status](https://travis-ci.com/unknownv2/CloudKit.svg?branch=master)](https://travis-ci.com/unknownv2/CloudKit)                                                 |
+
 ## CLI
 
 Check out the [source code for the tool](CloudKit.Cli/Program.cs) for examples on downloading and uploading files by using a game's AppID. You can search and find ID's with [SteamDB](https://steamdb.info/apps/).


### PR DESCRIPTION
* Add build configurations for the CloudKit project for the Travis CI and AppVeyor build servers.
* Remove an unused variable in the CLI example code for better clarity.